### PR TITLE
Updated extension to work with latest YouTube API

### DIFF
--- a/AdieuProfanity/anEventPage.js
+++ b/AdieuProfanity/anEventPage.js
@@ -131,7 +131,6 @@ function validateTextArea(text){
 
 function storeWord(contextWord,typeOfWord){
 	var i,flgRepeated=false;
-	var tempList=[];
 	var defaults={
 		//Complete
 		"curseComplete":"[]","humiliatingComplete":"[]","degradingComplete":"","blasphemyComplete":"","sexismComplete":"[]","racismComplete":"[]","homophobiaComplete":"[]","explicitComplete":"[]","immodestyComplete":"[]","nudityComplete":"[]","triumphalismComplete":"[]","elitismComplete":"[]","arroganceComplete":"[]","isolationismComplete":"[]","bullyingComplete":"[]","drugsComplete":"[]",
@@ -159,190 +158,36 @@ function storeWord(contextWord,typeOfWord){
 		'profanityList':['']
 	};
 	
+	const keys = [
+		"triumphalism", "isolationism", "elitism", "nudity", "curse", "degrading", "humiliating", "arrogance", "immodesty",
+		"blasphemy", "sexism", "racism", "homophobia", "drugs", "explicit", "bullying",
+		"custom",
+	];
+
 	chrome.storage.sync.get(defaults,function(settings){
 		if(typeOfWord=="complete"){
-			if(!flgRepeated){
-				tempList=settings.triumphalismComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.isolationismComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.elitismComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.nudityComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.curseComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.degradingComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.humiliatingComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.arroganceComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.immodestyComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.blasphemyComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.sexismComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.racismComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.homophobiaComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.drugsComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.explicitComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.bullyingComplete.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.customComplete.split(',');
-				for(i=0;i<tempList.length;i++){
-					console.log("customComplete: "+tempList[i]);
-					if(tempList[i]==contextWord) flgRepeated=true;
+			// v-changed (old did not use loop!)
+			for (const key of keys) {
+				const tempList=settings[key + "Complete"].split(',');
+				if (tempList.includes(contextWord)) {
+					flgRepeated = true;
+					break;
 				}
 			}
 		}else if(typeOfWord=="nested"){
-			if(!flgRepeated){ 
-				tempList=settings.triumphalismNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.isolationismNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.elitismNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.nudityNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.curseNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.degradingNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.humiliatingNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.arroganceNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.immodestyNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.blasphemyNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.sexismNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.racismNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.homophobiaNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.drugsNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.explicitNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.bullyingNested.split(',');
-				for(i=0;i<tempList.length;i++)
-					if(tempList[i]==contextWord) flgRepeated=true;
-			}
-			if(!flgRepeated){
-				tempList=settings.customNested.split(',');
-				for(i=0;i<tempList.length;i++){
-					//console.log("customNested: "+tempList[i]);
-					if(tempList[i]==contextWord) flgRepeated=true;
+			// v-changed (old did not use loop!)
+			for (const key of keys) {
+				const tempList=settings[key + "Nested"].split(',');
+				if (tempList.includes(contextWord)) {
+					flgRepeated = true;
+					break;
 				}
 			}
 		}else if(typeOfWord=="exception"){
-			if(!flgRepeated){
-				tempList=settings.wordListExceptions.split(',');
-				for(i=0;i<tempList.length;i++){
-					//console.log("customNested: "+tempList[i]);
-					if(tempList[i]==contextWord) flgRepeated=true;
-				}
+			// v-changed
+			const tempList=settings.wordListExceptions.split(',');
+			if (tempList.includes(contextWord)) {
+				flgRepeated=true;
 			}
 		}
 		

--- a/AdieuYTProfanity/options.html
+++ b/AdieuYTProfanity/options.html
@@ -33,6 +33,11 @@
 		  <input type="checkbox" id="muteSentence" >
 		  <label for="muteSentence">Mute complete sentence</label>
 		</div>
+
+		<div>
+			<input type="checkbox" id="muteGenerics" >
+			<label for="muteGenerics">Mute generics ("[music]", "[applause]", etc.)</label>
+		 </div>
 		
 		<div style="display: none;">
 		  <input type="checkbox" id="toMute">
@@ -112,8 +117,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="triumphalismNested"></textarea></td>
 				<td><textarea id="triumphalismComplete"></textarea></td>
+				<td><textarea id="triumphalismNested"></textarea></td>
 			</tr>
 			<tr>
 			<tr>
@@ -124,8 +129,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="isolationismNested"></textarea></td>
 				<td><textarea id="isolationismComplete"></textarea></td>
+				<td><textarea id="isolationismNested"></textarea></td>
 			</tr>
 			<td colspan="2">Elitism</td>
 			</tr>
@@ -134,8 +139,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="elitismNested"></textarea></td>
 				<td><textarea id="elitismComplete"></textarea></td>
+				<td><textarea id="elitismNested"></textarea></td>
 			</tr>
 			
 			
@@ -148,8 +153,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="nudityNested"></textarea></td>
 				<td><textarea id="nudityComplete"></textarea></td>
+				<td><textarea id="nudityNested"></textarea></td>
 			</tr>
 			
 			
@@ -162,8 +167,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="curseNested"></textarea></td>
 				<td><textarea id="curseComplete"></textarea></td>
+				<td><textarea id="curseNested"></textarea></td>
 			</tr>
 		</table>
 		
@@ -179,8 +184,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="degradingNested"></textarea></td>
 				<td><textarea id="degradingComplete"></textarea></td>
+				<td><textarea id="degradingNested"></textarea></td>
 			</tr>
 			<tr>
 				<td colspan="2">Humiliating</td>
@@ -190,8 +195,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="humiliatingNested"></textarea></td>
 				<td><textarea id="humiliatingComplete"></textarea></td>
+				<td><textarea id="humiliatingNested"></textarea></td>
 			</tr>
 			
 			<tr>
@@ -202,8 +207,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="arroganceNested"></textarea></td>
 				<td><textarea id="arroganceComplete"></textarea></td>
+				<td><textarea id="arroganceNested"></textarea></td>
 			</tr>
 			
 			
@@ -216,8 +221,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="immodestyNested"></textarea></td>
 				<td><textarea id="immodestyComplete"></textarea></td>
+				<td><textarea id="immodestyNested"></textarea></td>
 			</tr>
 		</table>
 		
@@ -233,8 +238,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="blasphemyNested"></textarea></td>
 				<td><textarea id="blasphemyComplete"></textarea></td>
+				<td><textarea id="blasphemyNested"></textarea></td>
 			</tr>
 			<tr>
 				<td colspan="2">Sexism</td>
@@ -244,8 +249,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="sexismNested"></textarea></td>
 				<td><textarea id="sexismComplete"></textarea></td>
+				<td><textarea id="sexismNested"></textarea></td>
 			</tr>
 			<tr>
 				<td colspan="2">Racism</td>
@@ -255,8 +260,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="racismNested"></textarea></td>
 				<td><textarea id="racismComplete"></textarea></td>
+				<td><textarea id="racismNested"></textarea></td>
 			</tr>
 			<tr>
 				<td colspan="2">Homophobia</td>
@@ -266,8 +271,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="homophobiaNested"></textarea></td>
 				<td><textarea id="homophobiaComplete"></textarea></td>
+				<td><textarea id="homophobiaNested"></textarea></td>
 			</tr>
 			
 			
@@ -280,8 +285,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="drugsNested"></textarea></td>
 				<td><textarea id="drugsComplete"></textarea></td>
+				<td><textarea id="drugsNested"></textarea></td>
 			</tr>
 			
 			
@@ -294,8 +299,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="explicitNested"></textarea></td>
 				<td><textarea id="explicitComplete"></textarea></td>
+				<td><textarea id="explicitNested"></textarea></td>
 			</tr>
 			
 			
@@ -308,8 +313,8 @@
 				<td>Nested words</td>
 			</tr>
 			<tr>
-				<td><textarea id="bullyingNested"></textarea></td>
 				<td><textarea id="bullyingComplete"></textarea></td>
+				<td><textarea id="bullyingNested"></textarea></td>
 			</tr>
 		</table>
 	

--- a/AdieuYTProfanity/options.js
+++ b/AdieuYTProfanity/options.js
@@ -389,7 +389,7 @@ function restore_options() {
 		"sexismNested":"biatch,whore,bitch,slut",
 		"racismNested":"",
 		"homophobiaNested":"maricon,faggot",
-		"explicitNested":"feck,masturbate,suck",
+		"explicitNested":"feck,masturbate",
 		"immodestyNested":"flaps",
 		"nudityNested":"gash,orto,beaver,clunge,cock,dick,knob,penis,prick,punani,pussy,twat",
 		"triumphalismNested":"",


### PR DESCRIPTION
Changelog:
* Fixed `getYouTubeCaptionURL()` to work with latest YouTube API. (it no longer has a working `get_video_info` endpoint)
* Fixed `generateProfanityList()` to also match on `[ __ ]` text in subtitles. (which is what most profanity is now replaced with within the YouTube subtitles text)
* Fixed that the "complete" group-boxes for the profanity-list were shown in the "nested" column, and vice-versa.
* Added new setting, which defaults to false, rather than the old behavior of true: Mute generics ("[music]", "[applause]", etc.)
* Made-so the "square" element (saying overview of amount of profanity and such) has "pointer-events:none"; this fixes that the square was blocking mouse inputs to controls behind it, in some cases.
* Made-so the "current video-id" is checked if it needs updating once per second. (the checking process is very fast, as it just reads from the URL; and this fixes some url-changing cases that are not handled by the existing listeners)
* Cleaned up the code in some places.
* Added "butter" to the list of word-exceptions.
* Removed "suck" from the "explicitNested" list. (too many false-positives)